### PR TITLE
Allow pycoreconf to add multiple SID definition files for a given model

### DIFF
--- a/pycoreconf/pycoreconf.py
+++ b/pycoreconf/pycoreconf.py
@@ -40,11 +40,12 @@ class CORECONFModel(ModelSID):
     to convert to and from CORECONF/CBOR representation."""
 
     def __init__(self, 
-                 sid_file, 
+                 *sid_files, 
                  model_description_file=None):
+        
         self.model_description_file = model_description_file
         self.yang_ietf_modules_paths = ["."]
-        ModelSID.__init__(self, sid_file)
+        ModelSID.__init__(self, *sid_files)
 
     def add_modules_path(self, path):
         """

--- a/pycoreconf/sid.py
+++ b/pycoreconf/sid.py
@@ -5,8 +5,8 @@ class ModelSID:
     Class to define methods for reading a YANG model SID file and hold values.
     """
 
-    def __init__(self, sid_file):
-        self.sid_file = sid_file
+    def __init__(self, *sid_files):
+        self.sid_files = sid_files
         self.sids, self.types, self.name = self.getSIDsAndTypes() #req. ltn22/pyang
         self.ids = {v: k for k, v in self.sids.items()} # {sid:id}
 
@@ -14,23 +14,32 @@ class ModelSID:
         """
         Read SID file and return { identifier : sid } + { identifier : type } dictionaries.
         """
-        # Read the contents of the sid/json file
-        f = open(self.sid_file, "r")
-        obj = json.load(f)
-        f.close()
-
-        # Get items & map identifier : sid and leafIdentifier : typename
         sids = {} # init
         types = {} # init
-        items = obj["items"] # list
-        for item in items:
-            sids[item["identifier"]] = item["sid"]
-            if "type" in item.keys():
-                types[item["identifier"]] = item["type"]
+        names = []
 
-        # tmp while single module support:
-        name = obj["module-name"]
+        for sid_file in self.sid_files:
+            
+            # Read the contents of the sid/json files
+            f = open(sid_file, "r")
+            obj = json.load(f)
+            f.close()
 
+            # Get items & map identifier : sid and leafIdentifier : typename
+
+            items = obj["items"] # list
+            for item in items:
+                sids[item["identifier"]] = item["sid"]
+                if "type" in item.keys():
+                    types[item["identifier"]] = item["type"]
+
+            # tmp while single module support:
+            names.append(obj["module-name"])
+
+        # NOTE IF there are multiple SID files, the names will be concatenated
+        # Concatenate all the names separated by a comma
+        name = ', '.join(names)
+        print("SIDS ", len(sids), len(types))
         return sids, types, name
 
 
@@ -38,16 +47,18 @@ class ModelSID:
         """
         Read SID file and return { sid : identifier } dictionary.
         """
-        # Read the contents of the sid/json file
-        f = open(self.sid_file, "r")
-        obj = json.load(f)
-        f.close()
 
-        # Get items & map identifier : sid
-        ids = {} # init
-        items = obj["items"] # list
-        for item in items:
-            ids[item["sid"]] = item["identifier"]
+        for sid_file in self.sid_files:
+            # Read the contents of the sid/json file
+            f = open(sid_file, "r")
+            obj = json.load(f)
+            f.close()
+
+            # Get items & map identifier : sid
+            ids = {} # init
+            items = obj["items"] # list
+            for item in items:
+                ids[item["sid"]] = item["identifier"]
 
         return ids
 
@@ -55,15 +66,16 @@ class ModelSID:
         """
         Read SID file and return { identifier : sid } dictionary.
         """
-        # Read the contents of the sid/json file
-        f = open(self.sid_file, "r")
-        obj = json.load(f)
-        f.close()
-
-        # Get items & map identifier : sid
         sids = {} # init
-        items = obj["items"] # list
-        for item in items:
-            sids[item["identifier"]] = item["sid"]
+        for sid_file in self.sid_files:
+            # Read the contents of the sid/json file
+            f = open(self.sid_file, "r")
+            obj = json.load(f)
+            f.close()
+
+            # Get items & map identifier : sid
+            items = obj["items"] # list
+            for item in items:
+                sids[item["identifier"]] = item["sid"]
 
         return sids


### PR DESCRIPTION
This allows pycoreconf to add multiple SID definition files for a given data-model as described in [OpenSCHC example on line 22](https://github.com/ltn22/openschc/blob/master/examples/datamodel/data_model.py#L22)