### PR TITLE
Trivial fix: Work on old .sid files and new .sid files 

### DIFF
--- a/pycoreconf/pycoreconf.py
+++ b/pycoreconf/pycoreconf.py
@@ -190,7 +190,7 @@ class CORECONFModel(ModelSID):
 
         # Transform to CORECONF/CBOR
         # valid = validateConfig(py_dict) #  ?
-        cc = self.lookupSIDWithoutRecursion(py_dict)
+        cc = self.lookupSIDWithoutRecursion(py_dict, parent=self.moduleName)
         return cbor.dumps(cc)
 
     def lookupIdentifier(self, obj, delta=0, path="/"):

--- a/pycoreconf/pycoreconf.py
+++ b/pycoreconf/pycoreconf.py
@@ -190,7 +190,7 @@ class CORECONFModel(ModelSID):
 
         # Transform to CORECONF/CBOR
         # valid = validateConfig(py_dict) #  ?
-        cc = self.lookupSIDWithoutRecursion(py_dict, parent=self.moduleName)
+        cc = self.lookupSIDWithoutRecursion(py_dict, path=self.moduleName)
         return cbor.dumps(cc)
 
     def lookupIdentifier(self, obj, delta=0, path="/"):

--- a/pycoreconf/sid.py
+++ b/pycoreconf/sid.py
@@ -22,7 +22,12 @@ class ModelSID:
         # Get items & map identifier : sid and leafIdentifier : typename
         sids = {} # init
         types = {} # init
-        items = obj["item"] # list
+        items = obj.get("item") # list
+        
+        # Old SID models have "items" instead of "item" as key
+        if not items:
+            items = obj["items"] 
+
         for item in items:
             sids[item["identifier"]] = item["sid"]
             if "type" in item.keys():

--- a/pycoreconf/sid.py
+++ b/pycoreconf/sid.py
@@ -9,7 +9,7 @@ class ModelSID:
         self.sid_file = sid_file
         self.sids, self.types, self.name = self.getSIDsAndTypes() #req. ltn22/pyang
         self.ids = {v: k for k, v in self.sids.items()} # {sid:id}
-        self.moduleName = self.getModuleName
+        self.moduleName = self.getModuleName()
 
     def getModuleName(self):
         """

--- a/pycoreconf/sid.py
+++ b/pycoreconf/sid.py
@@ -22,7 +22,7 @@ class ModelSID:
         # Get items & map identifier : sid and leafIdentifier : typename
         sids = {} # init
         types = {} # init
-        items = obj["items"] # list
+        items = obj["item"] # list
         for item in items:
             sids[item["identifier"]] = item["sid"]
             if "type" in item.keys():
@@ -45,7 +45,7 @@ class ModelSID:
 
         # Get items & map identifier : sid
         ids = {} # init
-        items = obj["items"] # list
+        items = obj["item"] # list
         for item in items:
             ids[item["sid"]] = item["identifier"]
 
@@ -62,7 +62,7 @@ class ModelSID:
 
         # Get items & map identifier : sid
         sids = {} # init
-        items = obj["items"] # list
+        items = obj["item"] # list
         for item in items:
             sids[item["identifier"]] = item["sid"]
 

--- a/pycoreconf/sid.py
+++ b/pycoreconf/sid.py
@@ -9,6 +9,18 @@ class ModelSID:
         self.sid_file = sid_file
         self.sids, self.types, self.name = self.getSIDsAndTypes() #req. ltn22/pyang
         self.ids = {v: k for k, v in self.sids.items()} # {sid:id}
+        self.moduleName = self.getModuleName
+
+    def getModuleName(self):
+        """
+        Some SID with non-empty module-names are then used to fetch SID names while looking up SID
+        """
+        f = open(self.sid_file, "r")
+        obj = json.load(f)
+        f.close()
+        moduleName = obj.get("module-name")
+        formattedModuleName = "/%s:"%moduleName
+        return formattedModuleName
 
     def getSIDsAndTypes(self):
         """


### PR DESCRIPTION
Tiny change allows pycoreconf to work with old sid files (with key "items")  and new sid files (with key "item")