### PR TITLE
Fix SID (item) extraction in ModelSID

### DIFF
--- a/pycoreconf/sid.py
+++ b/pycoreconf/sid.py
@@ -35,10 +35,10 @@ class ModelSID:
         sids = {} # init
         types = {} # init
         items = obj.get("item") # list
-        
+
         # Old SID models have "items" instead of "item" as key
         if not items:
-            items = obj["items"] 
+            items = obj["items"]
 
         for item in items:
             sids[item["identifier"]] = item["sid"]
@@ -62,7 +62,12 @@ class ModelSID:
 
         # Get items & map identifier : sid
         ids = {} # init
-        items = obj["item"] # list
+        items = obj.get("item") # list
+
+        # Old SID models have "items" instead of "item" as key
+        if not items:
+            items = obj["items"]
+
         for item in items:
             ids[item["sid"]] = item["identifier"]
 
@@ -79,7 +84,12 @@ class ModelSID:
 
         # Get items & map identifier : sid
         sids = {} # init
-        items = obj["item"] # list
+        items = obj.get("item") # list
+
+        # Old SID models have "items" instead of "item" as key
+        if not items:
+            items = obj["items"]
+
         for item in items:
             sids[item["identifier"]] = item["sid"]
 


### PR DESCRIPTION
Hi,

thanks for providing a Python CORECONF encode/decoder implementation. I realized that the item vs items fix that went into ModelSID.getSIDsAndTypes() (with https://github.com/alex-fddz/pycoreconf/pull/7) should also be applied to ModelSID.getSIDs() and ModelSID.getIdentifiers(), shouldn't it?. This PR hopefully fixes that.

How to reproduce the original issue:

```
# Get YANG models
git clone https://github.com/YangModels/yang.git

# Build pycoreconf
(
git clone https://github.com/alex-fddz/pycoreconf.git
cd pycoreconf
python -m build
)

# Setup Python virtual environment with mbj4668/pyang
python -m venv .venv
(
source .venv/bin/activate
pip install pyang setuptools
ls -v pycoreconf/dist/*.whl | tail -1 | xargs pip install

# Generate SIDs, output is ieee802-dot1q-bridge@2023-10-26.sid
pyang --sid-generate 60000:10000 --sid-lis -p yang/standard/ yang/standard/ieee/published/802.1/ieee802-dot1q-bridge.yang

cat > item_test.py << EOF
import pycoreconf
ccm = pycoreconf.CORECONFModel('ieee802-dot1q-bridge@2023-10-26.sid')

try:
        print('testing getSIDsAndTypes()')
        ccm.getSIDsAndTypes()
        print('OK')
except KeyError:
        print('failed')

try:
        print('testing getSIDs()')
        ccm.getSIDs()
        print('OK')
except KeyError:
        print('failed')

try:
        print('testing getIdentifiers()')
        ccm.getIdentifiers()
        print('OK')
except KeyError:
        print('failed')
EOF
python3 item_test.py
)
```

Best regards,
Daniel