### PR TITLE
bug: fix typo, cope -> copy

### DIFF
--- a/src/pycoreconf/model.py
+++ b/src/pycoreconf/model.py
@@ -88,7 +88,7 @@ class CORECONFModel(ModelSID):
 
         _logger.debug("Encoding config (keys=%d)", len(config))
 
-        config_cpy = cope.deepcopy(config)
+        config_cpy = copy.deepcopy(config)
 
         # Transform to CORECONF
         sid_tree = self._identifier_to_sid_tree(config_cpy)


### PR DESCRIPTION
Fix typo. `cope` should be `copy`. UTs were failing before, now they pass.