### PR TITLE
Handle null value for non-leaf entry

### DIFF
--- a/src/pycoreconf/model.py
+++ b/src/pycoreconf/model.py
@@ -470,6 +470,10 @@ class CORECONFModel(ModelSID):
                     current_value[sid_diff] = _ValueWrapper(current_value.pop(key))
                     stack.append((current_value[sid_diff], qualified_path+"/", child_sid_value))
             
+            # current_value can be None if you are setting a list to be empty
+            elif current_value is None:
+                current_object.value = None
+
             # current_value is a list type, append each of the object in current_value to the stack
             elif type(current_value) == list:
                 for i in range(len(current_value)):
@@ -560,12 +564,18 @@ class CORECONFModel(ModelSID):
                     node_identifier = identifier[len(current_path):].lstrip("/")
                     current_value[node_identifier] = _ValueWrapper(current_value.pop(key))
                     stack.append((current_value[node_identifier], sid, identifier))
-        
+
             # current_value is a list type, append each of the object in currentValue to the stack
             elif type(current_value) is list:
                 for i in range(len(current_value)):
                     current_value[i] = _ValueWrapper(current_value[i])
                     stack.append((current_value[i], current_delta, current_path))
+
+            # current_value can be None if you fetch a value that has not yet
+            # been populated. i.e. the yang model contains a list,
+            # but currently it is empty.
+            elif current_value is None:
+                current_object.value = None
 
             # current_value is a leaf here, transform their datatype before adding to the current_object
             else:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -85,6 +85,23 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(original, parsed)
         self.assertEqual(config, json_str)
     
+    def test_decode_to_json_null(self):
+        """Test decode_to_json returns null value for empty list"""
+        ccm = self.make_ccm("samples/libconf/example-2.sid")
+        config = '{"example-2:bag/foo": null}'
+
+        cbor_data = ccm.encode_json(config)
+        json_str = ccm.decode_to_json(cbor_data)
+
+        parsed = json.loads(json_str)
+        original = json.loads(config)
+
+        self.assertIsInstance(cbor_data, bytes)
+        self.assertIsInstance(json_str, str)
+
+        self.assertEqual(original, parsed)
+        self.assertEqual(config, json_str)
+
     def test_encode_json_invalid_json_raises(self):
         """Test encode_json with invalid JSON string."""
         ccm = self.make_ccm("samples/basic/example-1.sid")


### PR DESCRIPTION
I found a condition where one might encounter a null value for a non-leaf entry. The specific example where I see this is a network switch whose yang model describes a list for access controls. That list is empty by default, and if you perform a fetch operation on that list, requesting say, index 1, then the resulting CBOR that is returned is:

`{<list_sid>: None}`

This PR handles this condition by making sure that None is translated to `null` and vice versa.