### PR TITLE
Added support for encoding into CBOR Decimal Tag

### DIFF
--- a/src/pycoreconf/model.py
+++ b/src/pycoreconf/model.py
@@ -2,6 +2,7 @@
 
 from .sid import ModelSID
 from .datastore import CORECONFDatastore
+from decimal import Decimal
 from typing import Union
 import json
 import base64
@@ -326,6 +327,7 @@ class CORECONFModel(ModelSID):
 
         # XXX: Refactor and/or split (encoding/decoding) this function.
 
+        DECIMAL_FRACTION_CBOR_TAG_VALUE = 4
         BITS_CBOR_TAG_VALUE = 43
         ENUMERATION_CBOR_TAG_VALUE = 44
         IDENTITYREF_CBOR_TAG_VALUE = 45
@@ -390,6 +392,13 @@ class CORECONFModel(ModelSID):
                     return leaf.hex()
                 else:
                     return leaf
+            elif dtype == "ieee802-eth-if:eth-if-speed-type":
+                # When encoding this to cbor we want to use the appropriate
+                # CBOR decimal fraction tag, and cbor2 does that with the
+                # Decimal data type
+                if to_cbor:
+                    return Decimal(leaf)
+
             elif dtype in ["empty", "leafref", "instance-identifier"]: # just return obj
                 _logger.warning("Data type %s not yet handled; returning value as-is.", dtype)
                 return leaf
@@ -428,7 +437,6 @@ class CORECONFModel(ModelSID):
         # RFC 7951: Fallback for Decimal objects (e.g., from unrecognized typedefs)
         # Decimal values must be strings in JSON to maintain precision
         if not to_cbor and not use_native_types:
-            from decimal import Decimal
             if isinstance(leaf, Decimal):
                 _logger.debug("Converting Decimal to string for JSON compatibility (value=%r)", leaf)
                 return str(leaf)


### PR DESCRIPTION
Hey Alex,

I had been having an issue where the switch I'm working with was not recognizing the CBOR data I was sending, and I chased it down to the fact that it is expecting these decimals to be in a CBOR tag. With this change this works as expected.

It's a simple change, but it does beg the question of how we should handle all of the myriad of data types that one can define in YANG. I added a check for this one, "ieee802-eth-if:eth-if-speed-type", but there are a ton of ones that are not currently supported, and it works fine because they are just passed through as is. Here's a smattering of the ones I see when I am converting an entire switch config:

```
pycoreconf.model - WARNING - Unrecognized type: dot1q-types:traffic-class-type; returning value as-is.
pycoreconf.model - WARNING - Unrecognized type: port-number-type; returning value as-is.
pycoreconf.model - WARNING - Unrecognized type: dot1qtypes:vid-range-type; returning value as-is.
pycoreconf.model - WARNING - Unrecognized type: dot1qtypes:name-type; returning value as-is.
pycoreconf.model - WARNING - Unrecognized type: if:interface-ref; returning value as-is.
pycoreconf.model - WARNING - Unrecognized type: ieee:mac-address; returning value as-is
```

I don't think we want a check inside _convert_leaf_value for all of these possible types, rather some way to have a "type plugin" where you can tell the tool how to want to handle some set of types. What do you think? For now are you ok with this PR and we can maybe add an issue ticket to make this better?